### PR TITLE
Add platform specific classes for keybindings

### DIFF
--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -1,7 +1,7 @@
-'body':
+'.platform-darwin body':
   'alt-cmd-n': 'outline-editor:new-outline'
 
-'ft-outline-editor':
+'.platform-darwin ft-outline-editor':
   # Platform Bindings
   'alt-left': 'editor:move-to-beginning-of-word'
   'alt-right': 'editor:move-to-end-of-word'

--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -1,7 +1,7 @@
-'body':
+'.platform-linux body':
   'ctrl-alt-n': 'outline-editor:new-outline'
 
-'ft-outline-editor':
+'.platform-linux ft-outline-editor':
   # Platform Bindings
   'ctrl-left': 'editor:move-to-beginning-of-word'
   'ctrl-right': 'editor:move-to-end-of-word'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -1,7 +1,7 @@
-'body':
+'.platform-win32 body':
   'ctrl-alt-n': 'outline-editor:new-outline'
 
-'ft-outline-editor':
+'.platform-win32 ft-outline-editor':
   # Platform Bindings
   'ctrl-left': 'editor:move-to-beginning-of-word'
   'ctrl-right': 'editor:move-to-end-of-word'


### PR DESCRIPTION
I'm on a Mac, but for some reason, FoldingText is loading key bindings from Windows and Linux:

![cursor_and_outline_ftml_-__users_shu_code_concierge_-_atom](https://cloud.githubusercontent.com/assets/992008/8660083/a505690a-2963-11e5-9720-e0a160b2d779.png)

I'm not sure why, but maybe naming files as `darwin.cson` / `linux.cson` / `win32.cson` is not sufficient for Atom packages, and we need to explicitly add selectors?

`atom-keymap` has this code, but not sure if this applies to packages:
https://github.com/atom/atom-keymap/blob/9df60bd09f4179784fd735f01f8b6211716bf079/src/keymap-manager.coffee#L366
